### PR TITLE
Modified server initialization; port shows correctly.

### DIFF
--- a/server/start.js
+++ b/server/start.js
@@ -39,7 +39,7 @@ if (module === require.main) {
     process.env.PORT || 1337,
     () => {
       console.log(`--- Started HTTP Server for ${pkg.name} ---`)      
-      console.log(`Listening on ${JSON.stringify(server.address())}`)
+      console.log(`Listening on ${JSON.stringify(server.address().port)}`)
     }
   )
 }


### PR DESCRIPTION
When I `npm start`-ed, the console showed me:

`--- Started HTTP Server for mhia_website ---`
`Listening on {"address":"::","family":"IPv6","port":1337}`
`...`

until I modified the server.address() method. I now get:

`--- Started HTTP Server for mhia_website ---`
`Listening on 1337`
`...`

Not sure if this was due to a change in the Node http module's API?